### PR TITLE
Drop deprecated curl_close() call (PHP 8.5)

### DIFF
--- a/src/Controller/MelisMarketPlaceController.php
+++ b/src/Controller/MelisMarketPlaceController.php
@@ -1839,7 +1839,8 @@ class MelisMarketPlaceController extends MelisAbstractActionController
         curl_exec($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-        curl_close($ch);
+        // curl_close() is a no-op since PHP 8.0 (curl handles are CurlHandle objects,
+        // freed automatically) and is deprecated on 8.5 — omitted.
 
         return $httpCode < 400;
     }


### PR DESCRIPTION
## Problem
`curl_close()` is **deprecated on PHP 8.5** ("no effect since PHP 8.0"). Since 8.0 curl handles are `CurlHandle` objects freed automatically when they go out of scope, so the call does nothing. The notice shows in the back-office on 8.5.

## Fix
Remove the single `curl_close($ch)` call in `MelisMarketPlaceController`. No behaviour change (package requires `^8.1`). `php -l` clean on 8.1 and 8.5.

## Context
Found while bringing Melis up on PHP 8.5 end-to-end. Part of the 8.5 effort tracked in melisplatform/melis-core#28 (see also melis-installer#23, melis-core#29, melis-docker#9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)